### PR TITLE
Allow a node to have its parent changed.

### DIFF
--- a/model/uiState.py
+++ b/model/uiState.py
@@ -37,6 +37,9 @@ class UIState():
     # Whether the current point is being moved (True) or just selected (False)
     isMoving = attr.ib(default=False)
 
+    # Whether the current point is being reparented (True) or just selected (False)
+    isReparenting = attr.ib(default=False)
+
     # UI Option for whether or not to show annotations.
     showAnnotations = attr.ib(default=False, metadata=SAVE_META)
 
@@ -98,6 +101,8 @@ class UIState():
                 self.currentPointID = None
                 self.currentBranchID = None
                 self.isMoving = False
+        self.isReparenting = False
+
 
     def addPointToCurrentBranchAndSelect(self, location, newPointID=None, newBranchID=None):
         newPoint = Point(self.maybeCreateNewID(newPointID), location)

--- a/ui/actions/dendriteCanvasActions.py
+++ b/ui/actions/dendriteCanvasActions.py
@@ -112,4 +112,8 @@ class DendriteCanvasActions():
             "Registration complete! Unregistered points shown in green, press 'h' to toggle hilight.", parent=self.canvas)
         msg.show()
         self.canvas.stackWindow.statusBar().clearMessage()
-        # self.canvas.stackWindow.repaint()
+
+    def startReplaceParent(self):
+        self.uiState.isMove = False
+        self.uiState.isReparenting = True
+        self.canvas.redraw()

--- a/ui/dendritePainter.py
+++ b/ui/dendritePainter.py
@@ -25,6 +25,7 @@ class DendritePainter():
     NODE_CIRCLE_BRUSH = QBrush(Qt.white)
     NODE_CIRCLE_SELECTED_BRUSH = QBrush(Qt.cyan)
     NODE_CIRCLE_MOVING_BRUSH = QBrush(Qt.red)
+    NODE_CIRCLE_REPARENTING_BRUSH = QBrush(Qt.blue)
     HILIGHTED_CIRCLE_BRUSH = QBrush(Qt.green)
 
     ANNOTATION_PEN = QPen(QBrush(Qt.yellow), 1, Qt.SolidLine)
@@ -73,7 +74,11 @@ class DendritePainter():
     def drawCircleThisZ(self, x, y, isSelected, isHilighted):
         brushColor = self.NODE_CIRCLE_BRUSH
         if isSelected:
-            brushColor = self.NODE_CIRCLE_MOVING_BRUSH if self.uiState.isMoving else self.NODE_CIRCLE_SELECTED_BRUSH
+            brushColor = self.NODE_CIRCLE_SELECTED_BRUSH
+            if self.uiState.isMoving:
+                brushColor = self.NODE_CIRCLE_MOVING_BRUSH
+            elif self.uiState.isReparenting:
+                brushColor = self.NODE_CIRCLE_REPARENTING_BRUSH 
         elif isHilighted and self.uiState.showHilighted:
             brushColor = self.HILIGHTED_CIRCLE_BRUSH
         self.p.setPen(self.NODE_CIRCLE_PEN)

--- a/ui/dendriteVolumeCanvas.py
+++ b/ui/dendriteVolumeCanvas.py
@@ -88,8 +88,14 @@ class DendriteVolumeCanvas(QWidget):
             if closestDist is None or closestDist >= nearDistWorldSize:
                 pointClicked = None
 
-            # Handle Right-click/ctrl first; either delete the point, or start a new branch.
-            if rightClick or ctrlPressed:
+            # Handle reparent first: either reparent, or cancel reparenting.
+            if self.uiState.isReparenting:
+                if pointClicked:
+                    self.fullActions.reparent(self.windowIndex, pointClicked)
+                else:
+                    self.uiState.isReparenting = False # Nothing clicked, cancel reparent action
+            # Next, Right-click/ctrl first; either delete the point, or start a new branch.
+            elif rightClick or ctrlPressed:
                 if pointClicked:
                     self.fullActions.deletePoint(self.windowIndex, pointClicked, laterStacks=shiftPressed)
                 else:

--- a/ui/helpDialog.py
+++ b/ui/helpDialog.py
@@ -2,6 +2,8 @@ from PyQt5 import QtCore
 from PyQt5.QtWidgets import QDialog, QLabel, QMessageBox, QVBoxLayout
 
 HELP_MSG = """
+<table><tr><td>
+
 <h1>Mouse</h1>
 <h3>Clicking on a point...</h3>
 <ul>
@@ -21,7 +23,20 @@ HELP_MSG = """
   <li><b>Shift-Scroll</b> to zoom in and out.</li>
 </ul>
 
+</td><td>
+
 <h1>Shortcuts</h1>
+<h3>Drawing</h3>
+<ul>
+  <li><b>Q</b> to annotate a point</li>
+  <li><b>Ctrl-R</b> to replace the parent of a point (click next on the new parent)</li>
+  <li><b>L</b> to set landmarks that allow for aligning volumes</li>
+</ul>
+<h3>Analysis</h3>
+<ul>
+  <li><b>3</b> to open a 3d wire model of the current volume</li>
+  <li><b>M</b> to show motility plots for all volumes</li>
+</ul>
 <h3>Navigation</h3>
 <ul>
   <li><b>1</b> and <b>2</b> to move through the Z stacks</li>
@@ -34,13 +49,6 @@ HELP_MSG = """
   <li><b>6</b> to reset brightness to default</li>
   <li><b>7</b> and <b>8</b> to change the upper brightness limit</li>
 </ul>
-<h3>Analysis</h3>
-<ul>
-  <li><b>3</b> to open a 3d wire model of the current volume</li>
-  <li><b>M</b> to show motility plots for all volumes</li>
-  <li><b>Q</b> to annotate a point
-  <li><b>L</b> to set landmarks that allow for aligning volumes</li>
-</ul>
 <h3>View options</h3>
 <ul>
   <li><b>C</b> to change the displayed channel (if available)</li>
@@ -48,16 +56,19 @@ HELP_MSG = """
   <li><b>V</b> to show/hide points away from the current Z plane</li>
   <li><b>H</b> to show/hide hilighted points</li>
   <li><b>J</b> to cycle different line thicknesses</li>
+  <li><b>T</b> to tile all the open images on screen</li>
 </ul>
 <h3>Project</h3>
 <ul>
-  <li><b>Ctrl-S</b> to save the current data to file</li>
+  <li><b>Ctrl-S</b> to save the current data over its current file</li>
+  <li><b>Ctrl-Shift-S</b> to save the current data to a new file</li>
   <li><b>N</b> to add a new image stack</li>
-  <li><b>T</b> to tile all the open images on screen</li>
   <li><b>I</b> to import tree structure and locations from the previous stack to the current one</li>
   <li><b>Ctrl-I</b> to import tree structure and locations from an .SWC file</li>
   <li><b>R</b> to adjust the current branch locations based off the branch in the previous stack</li>
 </ul>
+
+</td></tr></table>
 """
 
 class HelpDialog(QDialog):

--- a/ui/stackWindow.py
+++ b/ui/stackWindow.py
@@ -57,6 +57,7 @@ class StackWindow(QtWidgets.QMainWindow):
         self.edit_menu = QtWidgets.QMenu('&Edit', self)
         self.edit_menu.addAction('Undo', self.undo, QtCore.Qt.CTRL + QtCore.Qt.Key_Z)
         self.edit_menu.addAction('Redo', self.redo, QtCore.Qt.CTRL + QtCore.Qt.SHIFT + QtCore.Qt.Key_Z)
+        self.edit_menu.addAction('&Replace parent', self.reparent, QtCore.Qt.CTRL + QtCore.Qt.Key_R)
         self.menuBar().addMenu(self.edit_menu)
         self.help_menu = QtWidgets.QMenu('&Help', self)
         self.menuBar().addSeparator()
@@ -100,6 +101,9 @@ class StackWindow(QtWidgets.QMainWindow):
 
     def redo(self):
         self.parent().updateUndoStack(isRedo=True, originWindow=self)
+
+    def reparent(self):
+        self.actionHandler.startReplaceParent()
 
     def keyPressEvent(self, event):
         try:


### PR DESCRIPTION
When clicking on a point, Ctrl-R puts you in reparent mode (point turns blue)
Clicking on another point (not in the original point's subtree) will change the original point's parent to that point. Note that if the new parent is at the end of its current branch, that branch will be extended instead.